### PR TITLE
Ensure plugin directory exists before install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,5 @@ HELM_HOME ?= $(helm home)
 
 .PHONY: install
 install:
+	mkdir -p $(HELM_HOME)/plugins
 	cp -a $(PLUGINS) $(HELM_HOME)/plugins


### PR DESCRIPTION
Currently command to install (`make install`) fails with a fresh install of helm-plugins.